### PR TITLE
fix: correct migration script GRAR-1442

### DIFF
--- a/src/PostalRegistry.Projections.Legacy/Migrations/20200703090616_AddSyndicationItemCreatedAt.cs
+++ b/src/PostalRegistry.Projections.Legacy/Migrations/20200703090616_AddSyndicationItemCreatedAt.cs
@@ -16,7 +16,7 @@ namespace PostalRegistry.Projections.Legacy.Migrations
                 defaultValue: DateTimeOffset.UtcNow);
 
             // remove the default value
-            migrationBuilder.AddColumn<DateTimeOffset>(
+            migrationBuilder.AlterColumn<DateTimeOffset>(
                 name: "SyndicationItemCreatedAt",
                 schema: "PostalRegistryLegacy",
                 table: "PostalInformationSyndication",


### PR DESCRIPTION
### Impact of changing the migration:
**if migration was already excuted: default value is not removed**

- Production: migration is not yet deployed
- Staging: migration is not yet deployed
- local: verify manually if needed